### PR TITLE
correction of CHEBI ID of entry 'arenecarbaldehyde'

### DIFF
--- a/rxno.owl
+++ b/rxno.owl
@@ -569,7 +569,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22495">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17478"/>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RXNO</oboInOwl:hasOBONamespace>
-        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:22495</oboInOwl:id>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:33855</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arenecarbaldehyde</rdfs:label>
     </owl:Class>
     


### PR DESCRIPTION
correction of the CHEBI ID of the entry arenecarbaldehyde from incorrect CHEBI:22495 (actually belongs to the entry 'aminobenzoic acid') to the correct value CHEBI:33855